### PR TITLE
Fix the mixed up descriptions

### DIFF
--- a/serl_robot_infra/README.md
+++ b/serl_robot_infra/README.md
@@ -45,8 +45,8 @@ The HTTP server is used to communicate between the ROS controller and gym enviro
 
 | Request | Description |
 | --- | --- |
-| startimp | Stop the impedance controller |
-| stopimp | Start the impedance controller |
+| startimp | Start the impedance controller |
+| stopimp | Stop the impedance controller |
 | pose | Command robot to go to desired end-effector pose given in base frame (xyz+quaternion) |
 | getpos | Return current end-effector pose in robot base frame (xyz+rpy)|
 | getvel | Return current end-effector velocity in robot base frame |


### PR DESCRIPTION
Fixed a typo:
"Start" and "Stop" were mixed up in the description.

For reference, they are defined in code here:
https://github.com/rail-berkeley/hil-serl/blob/2c63a3e027e488c025621376b9dda58cd3baaa9d/serl_robot_infra/robot_servers/franka_server.py#L242-L253