### PR TITLE
Fix GripperCloseEnv

### DIFF
--- a/serl_robot_infra/franka_env/envs/wrappers.py
+++ b/serl_robot_infra/franka_env/envs/wrappers.py
@@ -189,7 +189,7 @@ class GripperCloseEnv(gym.ActionWrapper):
         self.action_space = Box(ub.low[:6], ub.high[:6])
 
     def action(self, action: np.ndarray) -> np.ndarray:
-        new_action = np.zeros((7,), dtype=np.float32)
+        new_action = np.full((7,), -1.0, dtype=np.float32)
         new_action[:6] = action.copy()
         return new_action
 


### PR DESCRIPTION
This fixes the GripperCloseEnv to force the gripper closing. Only values <-0.5 or >0.5 for gripper dim force closing and opening the gripper respectively. Current action value of 0 only forces the gripper position to remain the same.