### PR TITLE
fix(transformation): change adjoint matrix to homogeneous matrix when doing transformation

### DIFF
--- a/serl_robot_infra/franka_env/envs/franka_env.py
+++ b/serl_robot_infra/franka_env/envs/franka_env.py
@@ -217,7 +217,7 @@ class FrankaEnv(gym.Env):
 
         # GET ORIENTATION FROM ACTION
         self.nextpos[3:] = (
-            Rotation.from_euler("xyz", action[3:6] * self.action_scale[1])
+            Rotation.from_rotvec(action[3:6] * self.action_scale[1])
             * Rotation.from_quat(self.currpos[3:])
         ).as_quat()
 

--- a/serl_robot_infra/franka_env/utils/transformations.py
+++ b/serl_robot_infra/franka_env/utils/transformations.py
@@ -5,6 +5,7 @@ import numpy as np
 def construct_adjoint_matrix(tcp_pose):
     """
     Construct the adjoint matrix for a spatial velocity vector
+    Used for the robot controlled by twist.
     :args: tcp_pose: (x, y, z, qx, qy, qz, qw)
     """
     rotation = R.from_quat(tcp_pose[3:]).as_matrix()
@@ -22,6 +23,17 @@ def construct_adjoint_matrix(tcp_pose):
     adjoint_matrix[3:, :3] = skew_matrix @ rotation
     return adjoint_matrix
 
+def construct_transform_matrix(tcp_pose):
+    """
+    Construct the transform matrix from given pose.
+    Used for the robot controlled by pose like provided franka delta pose controller.
+    :args: tcp_pose: (x, y, z, qx, qy, qz, qw)
+    """
+    rotation = R.from_quat(tcp_pose[3:]).as_matrix()
+    transform_matrix = np.zeros((6, 6))
+    transform_matrix[:3, :3] = rotation
+    transform_matrix[3:, 3:] = rotation
+    return transform_matrix
 
 def construct_homogeneous_matrix(tcp_pose):
     """


### PR DESCRIPTION
Current codebase use adjoint matrix to do transformation in relative_env.py, which is consistent with paper's twist control statement.
However, the franka controller provided by hilserl is a delta pose controller. So homogeneous transformation matrix shoule be used instead of adjoint matrix. Some experiments have been down to show that using proper homogeneous matrix will obviously decrease the learning time espically when you open you rotation freedom.